### PR TITLE
Add a method to extract all orders from user history

### DIFF
--- a/gogapi/api.py
+++ b/gogapi/api.py
@@ -194,6 +194,21 @@ class GogApi:
     def web_orders_gogdata(self):
         return self.get_gogdata(urls.web("settings.orders"))
 
+    def web_orders_all_gogdata(self, canceled=0, completed=1, in_progress=0,
+                               not_redeemed=1, pending=0, redeemed=1):
+        page_index = 1
+        while True:
+            url = urls.web("settings.orders.args", canceled=canceled,
+                           completed=completed, in_progress=in_progress,
+                           not_redeemed=not_redeemed, page=page_index,
+                           pending=pending, redeemed=redeemed)
+            json_data = self.get_json(url)
+            yield json_data
+            if page_index == json_data['totalPages']:
+                return
+            page_index += 1
+
+
     def web_account_gamedetails(self, game_id):
         return self.get_json(urls.web("account.gamedetails", game_id))
 

--- a/gogapi/urls.py
+++ b/gogapi/urls.py
@@ -64,7 +64,8 @@ web_config = {
 
     "wallet": "/wallet",
 
-    "settings.orders": "/orders"
+    "settings.orders": "/orders",
+    "settings.orders.args": "/account/settings/orders/data?canceled={canceled:d}&completed={completed:d}&in_progress={in_progress:d}&not_redeemed={not_redeemed:d}&page={page:d}&pending={pending:d}&redeemed={redeemed:d}"
 }
 
 galaxy_config = {


### PR DESCRIPTION
While web_orders_gogdata() is able to acquire the most recent operations
in a user's history, occasionally we wish to go through its entirety.
This can be used to calculate the full amount already spent, determine
when a game was purchased or do more elaborate analysis such as how a
user changes behaviour or preferences since they created their GOG
account.

The new method was added with what are considered reasonable default
arguments.
At the same time, a new URL was added, supporting all the search
arguments for this query.